### PR TITLE
[added] position, angle offsets & model scale for bag model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ Install it on your server (Pre-release must not be installed on production serve
 
 ### General
 
-### SCP-096 Bag Model
-Description: Define the bag model that will be shown when SCP-096 will be bagged.
-Default: models/props_junk/MetalBucket01a.mdl
-
-*You should use the default bag model for now*
-
 ### Key
 Description: Define the key used to interact with SCP-096 Bag.
 Default: E
@@ -34,6 +28,25 @@ Default: E
 ### Notification Delay
 Description: How long will each notification of the module will be shown
 Default: 8
+
+### Bag Model
+### Model
+Description: Define the bag model that will be shown when SCP-096 will be bagged.
+Default: models/props_junk/MetalBucket01a.mdl
+
+*You should use the default bag model for now*
+
+### Position Offset
+Description: Set the position offset for drawing the bag model
+Default: 4.0, 3.0, 5.0
+
+### Rotation Offset
+Description: Set the angle offset for drawing the bag model
+Default: -15.0, 0.0, -90.0
+
+### Model Scale
+Description: Scales the bag model
+Default: 0.9
 
 ### Translation
 

--- a/lua/guthscp/modules/ctx096bag/main.lua
+++ b/lua/guthscp/modules/ctx096bag/main.lua
@@ -25,13 +25,6 @@ MODULE.menu = {
 			},
 			{
 				type = "TextEntry",
-				name = "SCP-096 Bag Model",
-				id = "bagmodel",
-				desc = "Define the bag model that will be shown when SCP-096 will be bagged.",
-				default = "models/props_junk/MetalBucket01a.mdl",
-			},
-			{
-				type = "TextEntry",
 				name = "Key",
 				id = "key",
 				desc = "Define the key used to interact with SCP-096 Bag.",
@@ -43,6 +36,38 @@ MODULE.menu = {
 				id = "notificationdelay",
 				desc = "How long will each notification of the module will be shown",
 				default = 8,
+			},
+			{
+				type = "Category",
+				name = "Bag Model"
+			},
+			{
+				type = "TextEntry",
+				name = "Model",
+				id = "bagmodel",
+				desc = "Define the bag model that will be shown when SCP-096 will be bagged.",
+				default = "models/props_junk/MetalBucket01a.mdl",
+			},
+			{
+				type = "Vector",
+				name = "Position Offset",
+				id = "bag_position_offset",
+				desc = "Set the position offset for drawing the bag model",
+				default = Vector( 4.0, 3.0, 5.0 ),
+			},
+			{
+				type = "Angle",
+				name = "Rotation Offset",
+				id = "bag_rotation_offset",
+				desc = "Set the angle offset for drawing the bag model",
+				default = Angle( -15.0, 0.0, -90.0 ),
+			},
+			{
+				type = "NumWang",
+				name = "Model Scale",
+				id = "bag_model_scale",
+				desc = "Scales the bag model",
+				default = 0.9,
 			},
 			{
 				type = "Category",

--- a/lua/weapons/ctx_096_bag/cl_init.lua
+++ b/lua/weapons/ctx_096_bag/cl_init.lua
@@ -35,12 +35,14 @@ hook.Add( "PostPlayerDraw" , "ctx_096_bag_draw" , function( ply )
                     
             if not attach then return end
                     
-            local pos = attach.Pos
-            local ang = attach.Ang
-                
-            model:SetModelScale(0.8, 0)
-            pos = pos + (ang:Forward() * -5) + (ang:Up() * -4) + (ang:Right() * 4)
-            ang:RotateAroundAxis(ang:Forward(), -90)
+            local ang = attach.Ang + config.bag_rotation_offset
+            local pos = attach.Pos - ang:Forward() * config.bag_position_offset.x 
+                                   - ang:Right() * config.bag_position_offset.y 
+                                   - ang:Up() * config.bag_position_offset.z
+
+            model:SetModelScale(config.bag_model_scale, 0)
+           -- pos = pos + (ang:Forward() * -5) + (ang:Up() * -4) + (ang:Right() * 4)
+            --ang:RotateAroundAxis(ang:Forward(), -90)
                 
             model:SetPos(pos)
             model:SetAngles(ang)


### PR DESCRIPTION
This [commit](https://github.com/Guthen/guthscpbase/commit/641e59963aef055f2864c48120265d9668d51015) from the base added `Vector` & `Angle` VGUI configuration types. 

Since it would be nice to have controls over the bag model position & angle, here are the changes:
+ [added] position, angle offsets & scale for bag model
+ [moved] bag model configuration into its own category
+ [configured] bag model configuration variables for the default bucket model

![image](https://github.com/Certurix/ctx096bag/assets/33220603/dde35466-4224-49fb-9c53-899c03f119b1)
